### PR TITLE
📦 Change to eslint and tsc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "@essential-projects/eslint-config"
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": "5minds-typescript/fast",
-  "rules": {
-    "@typescript-eslint/no-explicit-any": ["warning"]
-  }
-}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,16 +40,13 @@ pipeline {
     stage('lint') {
       steps {
         sh('node --version')
-        /* we do not want the linting to cause a failed build */
-        sh('npm run lint || true')
+        sh('npm run lint')
       }
     }
     stage('build') {
       steps {
         sh('node --version')
         sh('npm run build')
-        // sh('npm run build-schemas')
-        // sh('npm run build-doc')
       }
     }
     stage('test') {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,10 @@
     "loggerhythm": "~3.0.3"
   },
   "devDependencies": {
+    "@essential-projects/eslint-config": "^1.0.0",
     "@types/node": "^10.12.2",
-    "@typescript-eslint/eslint-plugin": "^1.7.0",
-    "@typescript-eslint/parser": "^1.7.0",
-    "eslint-config-5minds-typescript": "^1.0.0",
-    "eslint-plugin-6river": "^1.0.6",
-    "eslint-plugin-import": "^2.17.2",
-    "eslint-plugin-no-null": "^1.0.2",
+    "eslint": "^5.16.0",
+    "tsconfig": "^7.0.0",
     "typescript": "^3.4.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "Heiko Mathes <heiko.mathes@5minds.de>"
   ],
   "dependencies": {
-    "@essential-projects/bootstrapper_contracts": "feature~change_to_eslint_and_tsc",
-    "@essential-projects/scheduler_contracts": "feature~change_to_eslint_and_tsc",
+    "@essential-projects/bootstrapper_contracts": "^1.4.0",
+    "@essential-projects/scheduler_contracts": "^1.1.0",
     "addict-ioc": "~2.5.1",
     "cron": "^1.7.1",
     "loggerhythm": "~3.0.3"

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
     "typescript": "^3.4.5"
   },
   "scripts": {
-    "build": "npm run build-commonjs && npm run build-amd",
+    "clean": "rm -rf dist",
+    "build": "npm run clean && npm run build-commonjs && npm run build-amd",
     "build-commonjs": "tsc",
     "build-amd": "tsc --module amd --outDir ./dist/amd",
     "prepare": "npm run build",
-    "lint": "eslint --fix src/**/*.ts",
+    "lint": "eslint src/*.ts",
+    "lint-fix": "eslint --fix src/*.ts",
     "test": ":"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
+  "author": "5Minds IT-Solutions GmbH & Co. KG",
   "contributors": [
+    "Christian Werner <christian.werner@5minds.de>",
     "Heiko Mathes <heiko.mathes@5minds.de>"
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Extension for cron-like scheduling of functions",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "Heiko Mathes <heiko.mathes@5minds.de>"
   ],
   "dependencies": {
-    "@essential-projects/bootstrapper_contracts": "~1.3.0",
-    "@essential-projects/scheduler_contracts": "~1.0.0",
+    "@essential-projects/bootstrapper_contracts": "feature~change_to_eslint_and_tsc",
+    "@essential-projects/scheduler_contracts": "feature~change_to_eslint_and_tsc",
     "addict-ioc": "~2.5.1",
     "cron": "^1.7.1",
     "loggerhythm": "~3.0.3"

--- a/src/scheduler_extension.ts
+++ b/src/scheduler_extension.ts
@@ -32,7 +32,7 @@ export class SchedulerExtension implements ISchedulerExtension {
 
   protected async initializeSchedulers(): Promise<void> {
 
-    const schedulerNames: Array<string> = this.container.getKeysByTags(schedulerDiscoveryTag);
+    const schedulerNames = this.container.getKeysByTags(schedulerDiscoveryTag);
 
     this.container.validateDependencies();
 
@@ -40,17 +40,16 @@ export class SchedulerExtension implements ISchedulerExtension {
       await this.initializeScheduler(schedulerName);
     }
 
-    const jobLists = Object.values<ISchedulerController>(this.schedulers)
-      .map((scheduler: ISchedulerController): Array<CronJob> => {
-        return scheduler.jobs;
-      });
+    const jobLists = Object
+      .values<ISchedulerController>(this.schedulers)
+      .map((scheduler: ISchedulerController): Array<CronJob> => scheduler.jobs);
 
     this.jobs = [].concat(...jobLists);
   }
 
   protected async initializeScheduler(schedulerName: string): Promise<void> {
 
-    const schedulerIsNotRegistered: boolean = !this.container.isRegistered(schedulerName);
+    const schedulerIsNotRegistered = !this.container.isRegistered(schedulerName);
     if (schedulerIsNotRegistered) {
       throw new Error(`There is no scheduler registered for key '${schedulerName}'`);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "declarationDir": "./dist",
     "sourceMap": true,
     "experimentalDecorators": true
-  }
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
## Changes

1. Perform builds with pure tsc and remove gulp entirely
2. Switch from TSLint to ESLint
3. Implement the new styleguide we use with eslint
4. Let linter errors cause Jenkins build failures

## Issues

Part of https://github.com/essential-projects/essential_projects_meta/issues/1

PR: #2

## How to test the changes

- Running `npm run build` works a great deal faster than before
- Linting is now possible and works as expected
- The Jenkins Builds will also run approx. twice as fast as before